### PR TITLE
Draft: try adding capsid variant calling and resistance

### DIFF
--- a/sierralocal/nucaminohook.py
+++ b/sierralocal/nucaminohook.py
@@ -73,6 +73,7 @@ class NucAminoAligner():
         # initialize gene map
         self.pol_start = 2085
         self.pol_nuc_map = {
+            'CA': (1186, 1878),
             'PR': (2253, 2549),
             'RT': (2550, 4229),  # incorrectly includes RNAse, emulating sierrapy
             'IN': (4230, 5096)
@@ -374,8 +375,6 @@ class NucAminoAligner():
         """
         Determines the first POL gene that is present in 
         the query sequence, by virtue of gene breakpoints
-        TODO: sierra uses different minimum numbers of sites per gene
-        (40, 60 and 30 for PR, RT and IN)
         @param pol_aligned_sites: list, sublist holds alignment program
         output aligned POL sites
         @param pol_first_aa: int, location of first amino acid in pol
@@ -385,7 +384,12 @@ class NucAminoAligner():
          first na position in pol, last na position in pol]
         """
         # good here
-        min_overlap = {'PR': 40, 'RT': 60, 'IN': 30}
+        min_overlap = {
+            'PR': 40,
+            'RT': 60,
+            'IN': 30,
+            'CA': 30, # Arbitrary as could not find source for above thresholds
+            }
         genes = []
         for gene, bounds in self.gene_map.items():
             aa_start, aa_end = bounds


### PR DESCRIPTION
Starting to work on https://github.com/PoonLab/sierra-local/issues/108

Thanks @ArtPoon for initial response. Still not working so @WilliamZekaiWang would definitely value your input here.

Open questions from the PR so far (apologies as I am not an HIV expert):
- Are capsid coordinates correct? Derived from https://www.hiv.lanl.gov/components/sequence/HIV/search/help.html#region
- Where were `min_overlap` thresholds borrowed from? Could not find upon a quick search of the sierra/sierrapy repos
- Why no lenacapavir calling when using HIVDB v9.8 XML as is? I.e. what are we missing?
- Are the DRM comments hardcoded in sierra-local, and if so, how to update/get those from the XML for CAI?